### PR TITLE
Add SafeDecrypt corporate website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# refactored-waddle
+# SafeDecrypt Website
+
+SafeDecrypt is a professional ransomware recovery company offering decryption tools, consulting, and incident response services. This static website presents the brand and funnels visitors toward contacting SafeDecrypt or requesting a quote.
+
+## Branding
+- **Tagline:** Restoring Data, Rebuilding Trust
+- **Color Scheme:**
+  - Primary: `#003a6b` (deep blue)
+  - Secondary: `#0057b8` (bright blue)
+  - Accent: `#00a8e8` (light blue)
+  - Light Background: `#f4f7fb`
+  - Dark Text: `#222`
+
+## Page Layouts
+### Home (`index.html`)
+1. Header with logo and navigation.
+2. Hero section featuring tagline and "Request a Quote" CTA.
+3. Brief value proposition and trust-building bullet points.
+4. Footer and persistent live chat widget.
+
+### Services (`services.html`)
+1. Overview hero.
+2. Sections for Recovery, Decryption Tools, and Consulting.
+3. Embedded Ransomware Diagnosis tool allowing visitors to check file extensions.
+4. Footer and live chat.
+
+### Case Studies (`case-studies.html`)
+1. Hero introduction.
+2. Realistic success stories from manufacturing, healthcare, and legal sectors.
+3. Footer and live chat.
+
+### Blog (`blog/index.html` and posts)
+1. News-focused hero section.
+2. Articles highlighting ransomware groups and trends with internal links.
+3. Footer and live chat.
+
+### Guides & FAQs (`guides.html`)
+1. Hero banner.
+2. Common recovery questions, timelines, and prevention tips.
+3. Footer and live chat.
+
+### Contact (`contact.html`)
+1. Hero with reassuring copy.
+2. Interactive contact form (primary CTA).
+3. Footer and live chat widget.
+
+## Running
+This site is static. Open `index.html` in a browser to view. The contact form and chat widget are for demonstration purposes only and do not send data to a server.

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="SafeDecrypt ransomware news and analysis">
+  <title>Blog | SafeDecrypt</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+<header>
+  <img src="../img/logo.svg" alt="SafeDecrypt logo" height="30">
+  <nav>
+    <a href="../index.html">Home</a>
+    <a href="../services.html">Services</a>
+    <a href="../case-studies.html">Case Studies</a>
+    <a href="index.html">Blog</a>
+    <a href="../guides.html">Guides & FAQs</a>
+    <a href="../contact.html">Contact</a>
+  </nav>
+</header>
+<div class="hero">
+  <h1>Ransomware News & Analysis</h1>
+  <p>Insights on ransomware groups, attacks, and trends.</p>
+</div>
+<section>
+  <article>
+    <h2><a href="lockbit-analysis.html">Understanding the LockBit Ransomware Group</a></h2>
+    <p>An overview of LockBit's tactics, targets, and how SafeDecrypt counters their attacks.</p>
+  </article>
+  <article>
+    <h2><a href="ransomware-trends.html">Ransomware-as-a-Service Trends in 2023</a></h2>
+    <p>A look at the evolving RaaS landscape and what it means for defenders.</p>
+  </article>
+</section>
+<footer>
+  &copy; 2023 SafeDecrypt. All rights reserved.
+</footer>
+<button id="chat-toggle">Chat</button>
+<div id="chatbox">
+  <header>Live Chat - SafeDecrypt</header>
+  <textarea placeholder="Type your message..."></textarea>
+</div>
+<script src="../js/main.js"></script>
+</body>
+</html>

--- a/blog/lockbit-analysis.html
+++ b/blog/lockbit-analysis.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Analysis of LockBit ransomware">
+  <title>LockBit Ransomware Group | SafeDecrypt Blog</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+<header>
+  <img src="../img/logo.svg" alt="SafeDecrypt logo" height="30">
+  <nav>
+    <a href="../index.html">Home</a>
+    <a href="../services.html">Services</a>
+    <a href="../case-studies.html">Case Studies</a>
+    <a href="index.html">Blog</a>
+    <a href="../guides.html">Guides & FAQs</a>
+    <a href="../contact.html">Contact</a>
+  </nav>
+</header>
+<div class="hero">
+  <h1>Understanding the LockBit Ransomware Group</h1>
+</div>
+<section>
+  <p>LockBit has emerged as one of the most active ransomware groups, leveraging aggressive data leak tactics and sophisticated encryption methods. SafeDecrypt continuously updates its decryptors to stay ahead of the group’s evolving variants.</p>
+</section>
+<footer>
+  &copy; 2023 SafeDecrypt. All rights reserved.
+</footer>
+<button id="chat-toggle">Chat</button>
+<div id="chatbox">
+  <header>Live Chat - SafeDecrypt</header>
+  <textarea placeholder="Type your message..."></textarea>
+</div>
+<script src="../js/main.js"></script>
+</body>
+</html>

--- a/blog/ransomware-trends.html
+++ b/blog/ransomware-trends.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Ransomware-as-a-Service trends">
+  <title>Ransomware-as-a-Service Trends | SafeDecrypt Blog</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+<header>
+  <img src="../img/logo.svg" alt="SafeDecrypt logo" height="30">
+  <nav>
+    <a href="../index.html">Home</a>
+    <a href="../services.html">Services</a>
+    <a href="../case-studies.html">Case Studies</a>
+    <a href="index.html">Blog</a>
+    <a href="../guides.html">Guides & FAQs</a>
+    <a href="../contact.html">Contact</a>
+  </nav>
+</header>
+<div class="hero">
+  <h1>Ransomware-as-a-Service Trends in 2023</h1>
+</div>
+<section>
+  <p>RaaS operations are lowering the barrier to entry for cybercriminals, leading to an increase in opportunistic attacks. SafeDecrypt monitors emerging groups to provide early detection and rapid response.</p>
+</section>
+<footer>
+  &copy; 2023 SafeDecrypt. All rights reserved.
+</footer>
+<button id="chat-toggle">Chat</button>
+<div id="chatbox">
+  <header>Live Chat - SafeDecrypt</header>
+  <textarea placeholder="Type your message..."></textarea>
+</div>
+<script src="../js/main.js"></script>
+</body>
+</html>

--- a/case-studies.html
+++ b/case-studies.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="SafeDecrypt ransomware recovery case studies">
+  <title>Case Studies | SafeDecrypt</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <img src="img/logo.svg" alt="SafeDecrypt logo" height="30">
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="services.html">Services</a>
+    <a href="case-studies.html">Case Studies</a>
+    <a href="blog/index.html">Blog</a>
+    <a href="guides.html">Guides & FAQs</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<div class="hero">
+  <h1>Case Studies</h1>
+  <p>Real recovery stories showcasing our expertise.</p>
+</div>
+<section>
+  <h2>Manufacturing Firm Restores Operations</h2>
+  <p>A mid-sized manufacturer suffered a LockBit attack that halted production. SafeDecrypt isolated infected systems, deployed a custom decryptor, and restored 95% of data within 48 hours without paying the ransom.</p>
+</section>
+<section>
+  <h2>Healthcare Provider Protects Patient Data</h2>
+  <p>After a Conti breach, a regional hospital faced service disruptions and regulatory pressure. Our team recovered medical records, strengthened their security posture, and guided them through HIPAA breach reporting.</p>
+</section>
+<section>
+  <h2>Law Firm Avoids Reputation Damage</h2>
+  <p>SafeDecrypt assisted a law firm hit by REvil by negotiating a temporary data release while we decrypted critical case files, enabling uninterrupted client representation.</p>
+</section>
+<footer>
+  &copy; 2023 SafeDecrypt. All rights reserved.
+</footer>
+<button id="chat-toggle">Chat</button>
+<div id="chatbox">
+  <header>Live Chat - SafeDecrypt</header>
+  <textarea placeholder="Type your message..."></textarea>
+</div>
+<script src="js/main.js"></script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Contact SafeDecrypt for ransomware recovery services">
+  <title>Contact | SafeDecrypt</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <img src="img/logo.svg" alt="SafeDecrypt logo" height="30">
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="services.html">Services</a>
+    <a href="case-studies.html">Case Studies</a>
+    <a href="blog/index.html">Blog</a>
+    <a href="guides.html">Guides & FAQs</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<div class="hero">
+  <h1>Contact SafeDecrypt</h1>
+  <p>We're ready to help you recover from ransomware.</p>
+</div>
+<section>
+  <form id="contact-form">
+    <input type="text" name="name" placeholder="Your Name" required>
+    <input type="email" name="email" placeholder="Email" required>
+    <textarea name="message" placeholder="How can we assist you?" required></textarea>
+    <button class="cta" type="submit">Send Message</button>
+  </form>
+</section>
+<footer>
+  &copy; 2023 SafeDecrypt. All rights reserved.
+</footer>
+<button id="chat-toggle">Chat</button>
+<div id="chatbox">
+  <header>Live Chat - SafeDecrypt</header>
+  <textarea placeholder="Type your message..."></textarea>
+</div>
+<script src="js/main.js"></script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,109 @@
+:root {
+  --primary: #003a6b;
+  --secondary: #0057b8;
+  --accent: #00a8e8;
+  --light: #f4f7fb;
+  --dark: #222;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: var(--light);
+  color: var(--dark);
+}
+
+header {
+  background: var(--primary);
+  color: #fff;
+  padding: 10px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+header nav a {
+  color: #fff;
+  margin-left: 15px;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.hero {
+  background: var(--secondary);
+  color: #fff;
+  padding: 80px 20px;
+  text-align: center;
+}
+
+.hero h1 {
+  margin-top: 0;
+  font-size: 2.5em;
+}
+
+section {
+  padding: 40px 20px;
+  max-width: 1000px;
+  margin: auto;
+}
+
+button.cta {
+  background: var(--accent);
+  border: none;
+  color: #fff;
+  padding: 10px 20px;
+  font-size: 1em;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+footer {
+  background: var(--primary);
+  color: #fff;
+  text-align: center;
+  padding: 20px;
+  margin-top: 40px;
+}
+
+form input, form textarea {
+  width: 100%;
+  padding: 10px;
+  margin: 5px 0;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+#chatbox {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 300px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  display: none;
+}
+
+#chatbox header {
+  background: var(--secondary);
+  color: #fff;
+  padding: 10px;
+  cursor: pointer;
+}
+
+#chatbox textarea {
+  width: 100%;
+  height: 80px;
+}
+
+#chat-toggle {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 10px 15px;
+  border-radius: 50%;
+  cursor: pointer;
+}

--- a/guides.html
+++ b/guides.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Ransomware guides and FAQs by SafeDecrypt">
+  <title>Guides & FAQs | SafeDecrypt</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <img src="img/logo.svg" alt="SafeDecrypt logo" height="30">
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="services.html">Services</a>
+    <a href="case-studies.html">Case Studies</a>
+    <a href="blog/index.html">Blog</a>
+    <a href="guides.html">Guides & FAQs</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<div class="hero">
+  <h1>Guides & Frequently Asked Questions</h1>
+</div>
+<section>
+  <h2>How long does recovery take?</h2>
+  <p>Every incident is unique. Once we analyze your samples, most recoveries are completed within 24–72 hours.</p>
+  <h2>Should we pay the ransom?</h2>
+  <p>We advise against paying when possible. SafeDecrypt focuses on data restoration and legal compliance to minimize risk.</p>
+  <h2>How can we prevent future attacks?</h2>
+  <p>Implement regular backups, multi-factor authentication, and security awareness training. Our consultants can provide a tailored prevention plan.</p>
+</section>
+<footer>
+  &copy; 2023 SafeDecrypt. All rights reserved.
+</footer>
+<button id="chat-toggle">Chat</button>
+<div id="chatbox">
+  <header>Live Chat - SafeDecrypt</header>
+  <textarea placeholder="Type your message..."></textarea>
+</div>
+<script src="js/main.js"></script>
+</body>
+</html>

--- a/img/logo.svg
+++ b/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" fill="#003a6b" rx="5"/>
+  <text x="60" y="25" font-size="18" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">SafeDecrypt</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Professional ransomware recovery and decryption services by SafeDecrypt">
+  <title>SafeDecrypt | Ransomware Recovery Experts</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <img src="img/logo.svg" alt="SafeDecrypt logo" height="30">
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="services.html">Services</a>
+    <a href="case-studies.html">Case Studies</a>
+    <a href="blog/index.html">Blog</a>
+    <a href="guides.html">Guides & FAQs</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<div class="hero">
+  <h1>Restoring Data, Rebuilding Trust</h1>
+  <p>Rapid ransomware recovery and decryption services for businesses and individuals.</p>
+  <button class="cta" onclick="location.href='contact.html'">Request a Quote</button>
+</div>
+<section>
+  <h2>Why SafeDecrypt?</h2>
+  <p>SafeDecrypt combines cutting-edge decryption tools with seasoned incident response consultants to restore systems safely and quickly.</p>
+  <ul>
+    <li>24/7 emergency response</li>
+    <li>Proven track record across major ransomware families</li>
+    <li>Confidential and compliant with industry regulations</li>
+  </ul>
+</section>
+<footer>
+  &copy; 2023 SafeDecrypt. All rights reserved.
+</footer>
+<button id="chat-toggle">Chat</button>
+<div id="chatbox">
+  <header>Live Chat - SafeDecrypt</header>
+  <textarea placeholder="Type your message..."></textarea>
+</div>
+<script src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const contactForm = document.getElementById('contact-form');
+  if (contactForm) {
+    contactForm.addEventListener('submit', function(e) {
+      e.preventDefault();
+      alert('Thank you. A SafeDecrypt specialist will reach out shortly.');
+      contactForm.reset();
+    });
+  }
+
+  const chatToggle = document.getElementById('chat-toggle');
+  const chatbox = document.getElementById('chatbox');
+  if (chatToggle && chatbox) {
+    chatToggle.addEventListener('click', function() {
+      chatbox.style.display = 'block';
+    });
+    chatbox.querySelector('header').addEventListener('click', function() {
+      chatbox.style.display = 'none';
+    });
+  }
+
+  const diagnoseForm = document.getElementById('diagnose-form');
+  if (diagnoseForm) {
+    const data = {
+      '.lockbit': 'LockBit Ransomware - known for double extortion tactics.',
+      '.conti': 'Conti Ransomware - typically spreads via phishing emails.',
+      '.revil': 'REvil Ransomware - often targets managed service providers.'
+    };
+    diagnoseForm.addEventListener('submit', function(e) {
+      e.preventDefault();
+      const ext = document.getElementById('extension').value.toLowerCase();
+      const result = data[ext] || 'Extension not found. Contact SafeDecrypt for a custom analysis.';
+      document.getElementById('diagnosis-result').textContent = result;
+    });
+  }
+});

--- a/services.html
+++ b/services.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="SafeDecrypt ransomware recovery and decryption services">
+  <title>Services | SafeDecrypt</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <img src="img/logo.svg" alt="SafeDecrypt logo" height="30">
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="services.html">Services</a>
+    <a href="case-studies.html">Case Studies</a>
+    <a href="blog/index.html">Blog</a>
+    <a href="guides.html">Guides & FAQs</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+<div class="hero">
+  <h1>Our Services</h1>
+  <p>Comprehensive ransomware solutions tailored to your incident.</p>
+</div>
+<section>
+  <h2>Ransomware Recovery</h2>
+  <p>From initial containment to full system restoration, our specialists guide you through every phase of recovery while preserving evidence for investigations.</p>
+</section>
+<section>
+  <h2>Decryption Tools</h2>
+  <p>We maintain a private arsenal of proprietary decryptors and partner with global law enforcement to extend our capabilities.</p>
+</section>
+<section>
+  <h2>Consulting & Prevention</h2>
+  <p>Proactive assessments, incident response planning, and staff training to strengthen your defenses.</p>
+</section>
+<section>
+  <h2>Ransomware Diagnosis Tool</h2>
+  <form id="diagnose-form">
+    <label for="extension">Enter encrypted file extension:</label>
+    <input type="text" id="extension" placeholder="e.g., .lockbit" required>
+    <button class="cta" type="submit">Check</button>
+  </form>
+  <p id="diagnosis-result"></p>
+</section>
+<footer>
+  &copy; 2023 SafeDecrypt. All rights reserved.
+</footer>
+<button id="chat-toggle">Chat</button>
+<div id="chatbox">
+  <header>Live Chat - SafeDecrypt</header>
+  <textarea placeholder="Type your message..."></textarea>
+</div>
+<script src="js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create static corporate site for ransomware recovery firm SafeDecrypt
- Implement service descriptions, case studies, guides, blog, and contact form with live chat
- Provide branding guidelines, color scheme, and layout suggestions in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a30f2e228c83278e4657ef804b1d21